### PR TITLE
fix: update selected note in preview mode

### DIFF
--- a/src/frontend/main.js
+++ b/src/frontend/main.js
@@ -3,21 +3,15 @@ import { NoteList } from "./notelist.js"
 
 const main = function() {
     slider_attach(document.querySelector("#slider"));
-    const editor = new SimpleMDE({
-        element: document.querySelector('#editor'),
-        autoDownloadFontAwesome: false
-    });
 
-    const notelist = new NoteList(document.querySelector('#notelist'), editor);
+    const notelist = new NoteList(
+        document.querySelector('#notelist'), 
+        document.querySelector('#content'));
 
     document.querySelector('#add').addEventListener('click', async () => {
         const name = await note.create();
         notelist.add(name);
     }, false);
-
-    document.querySelector('#update').addEventListener('click', async () => {
-        notelist.update();
-    });
 
 };
 

--- a/src/frontend/note.js
+++ b/src/frontend/note.js
@@ -1,0 +1,75 @@
+
+class Note {
+
+    #name;
+    #editor_element;
+    #editor;
+    #link;
+
+    constructor(name, text, notelist, content) {
+        this.#name = name;
+        
+        this.#create_listentry(notelist);
+        this.#create_editor(content, text);
+    }
+
+    #create_listentry(notelist) {
+        const item = document.createElement('li');
+        notelist.element.appendChild(item);
+
+        this.#link = document.createElement('a');
+        item.appendChild(this.#link);
+        this.#link.textContent = this.#name;
+        this.#link.href = '#';
+        this.#link.addEventListener('click', async() => {
+            notelist.activate(this);
+        }, false);
+    }
+
+
+    #create_editor(content, text) {
+        this.#editor_element = document.createElement('div');
+        content.appendChild(this.#editor_element);
+
+        const textarea = document.createElement('textarea');
+        this.#editor_element.appendChild(textarea);
+        this.#editor = new SimpleMDE({
+            element: textarea,
+            autoDownloadFontAwesome: false
+        });
+
+        this.#editor.value(text);
+        this.#editor.togglePreview();
+        this.#hide();
+    }
+
+    get isPreviewActive() {
+        return this.#editor.isPreviewActive();
+    }
+
+    activate(previewActive) {
+        this.#link.classList.add('active');
+
+        if (previewActive != this.#editor.isPreviewActive()) {
+            this.#editor.togglePreview();
+        }
+        this.#show();
+    }
+
+    deactivate() {
+        this.#link.classList.remove('active');
+        this.#hide();
+    }
+
+    #show() {
+        this.#editor_element.classList.remove('hidden');
+    }
+
+    #hide() {
+        this.#editor_element.classList.add('hidden');
+    }
+
+}
+
+
+export { Note }

--- a/src/frontend/notelist.js
+++ b/src/frontend/notelist.js
@@ -1,39 +1,48 @@
+import { Note } from './note.js'
+
 class NoteList {
 
-    constructor(element, editor) {
-        this.element = element;
-        this.active_item = null;
-        this.editor = editor;
+    #element;
+    #active_note;
+    #content;
+
+    constructor(element, content) {
+        this.#element = element;
+        this.#active_note = null;
+        this.#content = content;
         this.update();
     }
 
     async update() {
-        this.element.innerHTML = '';
+        this.#element.innerHTML = '';
 
         const notes = await note.list();
-        for(const note of notes) {
-            this.add(note);
+        for(const name of notes) {
+            await this.add(name);
         }
     }
 
-    add(name) {
-        const item = document.createElement('li');
-        this.element.appendChild(item);
+    get element() {
+        return this.#element;
+    }
 
-        const link = document.createElement('a');
-        item.appendChild(link);
-        link.textContent = name;
-        link.href = '#';
-        link.addEventListener('click', async() => {
-            const content = await note.read(name);
-            this.editor.value(content);
-            if (this.active_item !== null) {
-                this.active_item.classList.remove('active');
-            }
-            this.active_item = link;
-            this.active_item.classList.add('active');
-        }, false);
+    activate(note) {
+        let isPreviewActive = true;
+        if (this.#active_note) {
+            this.#active_note.deactivate();
+            isPreviewActive = this.#active_note.isPreviewActive;
+        }
 
+        this.#active_note = note;
+        this.#active_note.activate(isPreviewActive);
+    }
+
+    async add(name) {
+        const text = await note.read(name);
+        const new_note = new Note(name, text, this, this.#content);
+        if (!this.#active_note) {
+            this.activate(new_note);
+        }
     }
 
 }

--- a/src/index.css
+++ b/src/index.css
@@ -42,5 +42,11 @@ body {
 }
 
 #notelist a:link.active {
-  color: red;
+  font-weight: bold;
 }
+
+.hidden {
+  display: none;
+  visibility: hidden;
+}
+

--- a/src/index.html
+++ b/src/index.html
@@ -13,14 +13,12 @@
     <div class="wrapper">
       <div id="sidebar">
         <input id="add" type="button" value="Add" />
-        <input id="update" type="button" value="Update" />
         <hr>
         <ul id="notelist"></ul>
       </div>
       <div id="slider" data-slider-target="sidebar" class="slider"></div>
 
-      <div class="content">
-        <textarea id="editor"></textarea>
+      <div class="content" id="content">
       </div>
     </div>
   </body>


### PR DESCRIPTION
This pull request fixes the issue that notes are not updated in preview mode.
Therefore, a note controller (called "note" - weak name :-() was introduced. We now have multiple instances of SimpleMDE, each for every note. There was also some magic necessary to synchronize the mode (preview vs. edit mode) of all instances.

This result in an short glitch when switching between notes:
- open a note in edit mode
- switch to anther mode
- activate preview mode
- switch back
- a short glitch appears

This happens because the note is still in edit mode and is switched to preview mode when it gets active.
I don't think that this is a problem, since it is a rare use case. I also expect similar glitches, when a single instance of SimpleMDE is used. In that case we would have to switch the contents which will result in glitches as well.

Minor changes:
- the contents of the first note will be shown on startup
- active notes are marked **bold** instead of red