### PR TITLE
Fix: display editor and preview in full height

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -30,6 +30,18 @@ body {
 
 .content {
   flex: 4 0px;
+  display: flex;
+  flex-direction: column;
+}
+
+.content > div {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+
+.CodeMirror {
+  flex: 1;
 }
 
 #notelist {
@@ -46,7 +58,7 @@ body {
 }
 
 .hidden {
-  display: none;
+  display: none!important;
   visibility: hidden;
 }
 


### PR DESCRIPTION
Due to an error (missing styling), the editor / preview is only shown with 300px height (min-height). Now, flex layout is used to display editor / preview in full height.